### PR TITLE
Cognito Authentication & Authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local .terraform directories
-*/.terraform/
+.terraform/
 
 # .tfstate files
 *.tfstate

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -13,6 +13,7 @@ resource "aws_api_gateway_rest_api" "ims_api" {
     move_stock_item_arn   = module.move_store_item.lambda_function_invoke_arn
     auth_test_user_arn    = module.auth_test_user.lambda_function_invoke_arn
     auth_test_admin_arn   = module.auth_test_admin.lambda_function_invoke_arn
+    get_credentials_arn   = module.get_credentials.lambda_function_invoke_arn
     cognito_user_pool_arn = aws_cognito_user_pool.ims_user_pool.arn
   })))
 

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -72,6 +72,47 @@ resource "aws_api_gateway_integration_response" "ims_api_auth_integration_respon
   depends_on = [aws_api_gateway_integration.ims_api_auth_integration]
 }
 
+// --------------------------------------------------------
+resource "aws_api_gateway_resource" "ims_api_auth_admin" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  parent_id   = aws_api_gateway_rest_api.ims_api.root_resource_id
+  path_part   = "auth_test_admin"
+}
+
+resource "aws_api_gateway_method" "ims_api_auth_admin_method" {
+  rest_api_id   = aws_api_gateway_rest_api.ims_api.id
+  resource_id   = aws_api_gateway_resource.ims_api_auth_admin.id
+  http_method   = "GET"
+  authorization = "COGNITO_USER_POOLS"
+  authorizer_id = aws_api_gateway_authorizer.cognito_token_authorizer.id
+}
+
+resource "aws_api_gateway_integration" "ims_api_auth_admin_integration" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
+  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = module.auth_test_admin.lambda_function_invoke_arn
+}
+
+resource "aws_api_gateway_method_response" "ims_api_auth_admin_method_response" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
+  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_integration_response" "ims_api_auth_admin_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
+  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
+  status_code = "200"
+
+  depends_on = [aws_api_gateway_integration.ims_api_auth_admin_integration]
+}
+
 # ---------------------------------------------------------
 # Deploy the API Gateway
 # ---------------------------------------------------------

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -2,7 +2,9 @@
 # - https://medium.com/@m.farhatmaher/how-to-deploy-a-dash-app-on-aws-lambda-with-terraform-cbaa2f2bf9b1
 # - https://atsss.medium.com/small-lambda-function-with-python-and-terraform-f3100015f970 
 
+# ---------------------------------------------------------
 # Create a REST API Gateway
+# ---------------------------------------------------------
 resource "aws_api_gateway_rest_api" "ims_api" {
   name        = "ims-rest-api.${terraform.workspace}"
   description = "REST API Gateway for the Inventory Management System"
@@ -16,8 +18,63 @@ resource "aws_api_gateway_rest_api" "ims_api" {
   }
 }
 
+# ---------------------------------------------------------
+# Create a Cognito User Pool Authorizer
+# ---------------------------------------------------------
+resource "aws_api_gateway_authorizer" "cognito_token_authorizer" {
+  name            = "cognito-token-auth"
+  rest_api_id     = aws_api_gateway_rest_api.ims_api.id
+  type            = "COGNITO_USER_POOLS"
+  identity_source = "method.request.header.Authorization"
+  provider_arns   = [aws_cognito_user_pool.ims_user_pool.arn]
+}
 
+# ---------------------------------------------------------
+# Test endpoints to verify authentication and authorization
+# ---------------------------------------------------------
+resource "aws_api_gateway_resource" "ims_api_auth" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  parent_id   = aws_api_gateway_rest_api.ims_api.root_resource_id
+  path_part   = "auth_test"
+}
+
+resource "aws_api_gateway_method" "ims_api_auth_method" {
+  rest_api_id   = aws_api_gateway_rest_api.ims_api.id
+  resource_id   = aws_api_gateway_resource.ims_api_auth.id
+  http_method   = "GET"
+  authorization = "COGNITO_USER_POOLS"
+  authorizer_id = aws_api_gateway_authorizer.cognito_token_authorizer.id
+}
+
+resource "aws_api_gateway_integration" "ims_api_auth_integration" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth.id
+  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = module.auth_test_user.lambda_function_invoke_arn
+}
+
+resource "aws_api_gateway_method_response" "ims_api_auth_method_response" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth.id
+  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_integration_response" "ims_api_auth_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.ims_api.id
+  resource_id = aws_api_gateway_resource.ims_api_auth.id
+  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
+  status_code = "200"
+
+  depends_on = [aws_api_gateway_integration.ims_api_auth_integration]
+}
+
+# ---------------------------------------------------------
 # Deploy the API Gateway
+# ---------------------------------------------------------
 resource "aws_api_gateway_deployment" "ims_api_deployment" {
   rest_api_id = aws_api_gateway_rest_api.ims_api.id
 
@@ -33,7 +90,9 @@ resource "aws_api_gateway_deployment" "ims_api_deployment" {
   }
 }
 
+# ---------------------------------------------------------
 # Create a stage for the deployment
+# ---------------------------------------------------------
 resource "aws_api_gateway_stage" "ims_api_stage_deployment" {
   deployment_id = aws_api_gateway_deployment.ims_api_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.ims_api.id

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -10,107 +10,15 @@ resource "aws_api_gateway_rest_api" "ims_api" {
   description = "REST API Gateway for the Inventory Management System"
 
   body = jsonencode(yamldecode(templatefile("${path.module}/openapi.yaml", {
-    move_stock_item_arn = module.move_store_item.lambda_function_invoke_arn
+    move_stock_item_arn   = module.move_store_item.lambda_function_invoke_arn
+    auth_test_user_arn    = module.auth_test_user.lambda_function_invoke_arn
+    auth_test_admin_arn   = module.auth_test_admin.lambda_function_invoke_arn
+    cognito_user_pool_arn = aws_cognito_user_pool.ims_user_pool.arn
   })))
 
   endpoint_configuration {
     types = ["REGIONAL"]
   }
-}
-
-# ---------------------------------------------------------
-# Create a Cognito User Pool Authorizer
-# ---------------------------------------------------------
-resource "aws_api_gateway_authorizer" "cognito_token_authorizer" {
-  name            = "cognito-token-auth"
-  rest_api_id     = aws_api_gateway_rest_api.ims_api.id
-  type            = "COGNITO_USER_POOLS"
-  identity_source = "method.request.header.Authorization"
-  provider_arns   = [aws_cognito_user_pool.ims_user_pool.arn]
-}
-
-# ---------------------------------------------------------
-# Test endpoints to verify authentication and authorization
-# ---------------------------------------------------------
-resource "aws_api_gateway_resource" "ims_api_auth" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  parent_id   = aws_api_gateway_rest_api.ims_api.root_resource_id
-  path_part   = "auth_test"
-}
-
-resource "aws_api_gateway_method" "ims_api_auth_method" {
-  rest_api_id   = aws_api_gateway_rest_api.ims_api.id
-  resource_id   = aws_api_gateway_resource.ims_api_auth.id
-  http_method   = "GET"
-  authorization = "COGNITO_USER_POOLS"
-  authorizer_id = aws_api_gateway_authorizer.cognito_token_authorizer.id
-}
-
-resource "aws_api_gateway_integration" "ims_api_auth_integration" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth.id
-  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
-
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = module.auth_test_user.lambda_function_invoke_arn
-}
-
-resource "aws_api_gateway_method_response" "ims_api_auth_method_response" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth.id
-  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
-  status_code = "200"
-}
-
-resource "aws_api_gateway_integration_response" "ims_api_auth_integration_response" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth.id
-  http_method = aws_api_gateway_method.ims_api_auth_method.http_method
-  status_code = "200"
-
-  depends_on = [aws_api_gateway_integration.ims_api_auth_integration]
-}
-
-// --------------------------------------------------------
-resource "aws_api_gateway_resource" "ims_api_auth_admin" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  parent_id   = aws_api_gateway_rest_api.ims_api.root_resource_id
-  path_part   = "auth_test_admin"
-}
-
-resource "aws_api_gateway_method" "ims_api_auth_admin_method" {
-  rest_api_id   = aws_api_gateway_rest_api.ims_api.id
-  resource_id   = aws_api_gateway_resource.ims_api_auth_admin.id
-  http_method   = "GET"
-  authorization = "COGNITO_USER_POOLS"
-  authorizer_id = aws_api_gateway_authorizer.cognito_token_authorizer.id
-}
-
-resource "aws_api_gateway_integration" "ims_api_auth_admin_integration" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
-  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
-
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = module.auth_test_admin.lambda_function_invoke_arn
-}
-
-resource "aws_api_gateway_method_response" "ims_api_auth_admin_method_response" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
-  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
-  status_code = "200"
-}
-
-resource "aws_api_gateway_integration_response" "ims_api_auth_admin_integration_response" {
-  rest_api_id = aws_api_gateway_rest_api.ims_api.id
-  resource_id = aws_api_gateway_resource.ims_api_auth_admin.id
-  http_method = aws_api_gateway_method.ims_api_auth_admin_method.http_method
-  status_code = "200"
-
-  depends_on = [aws_api_gateway_integration.ims_api_auth_admin_integration]
 }
 
 # ---------------------------------------------------------
@@ -121,22 +29,21 @@ resource "aws_api_gateway_deployment" "ims_api_deployment" {
 
   # Trigger the deployment when the resources change
   triggers = {
-    redeployment = sha1(jsonencode((aws_api_gateway_rest_api.ims_api.body)))
+    redeployment = sha1(aws_api_gateway_rest_api.ims_api.body)
   }
-
-  depends_on = [aws_api_gateway_rest_api.ims_api]
 
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [aws_api_gateway_rest_api.ims_api]
 }
 
 # ---------------------------------------------------------
 # Create a stage for the deployment
 # ---------------------------------------------------------
 resource "aws_api_gateway_stage" "ims_api_stage_deployment" {
+  stage_name    = "dev"
   deployment_id = aws_api_gateway_deployment.ims_api_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.ims_api.id
-
-  stage_name = "dev"
 }

--- a/cognito.tf
+++ b/cognito.tf
@@ -31,11 +31,13 @@ resource "aws_cognito_user_pool_ui_customization" "ims_user_pool_ui" {
 resource "aws_cognito_user_group" "ims_user_group" {
   user_pool_id = aws_cognito_user_pool.ims_user_pool.id
   name         = "Users"
+  role_arn     = aws_iam_role.cognito_user_role.arn
 }
 
 resource "aws_cognito_user_group" "ims_admin_group" {
   user_pool_id = aws_cognito_user_pool.ims_user_pool.id
   name         = "Admins"
+  role_arn     = aws_iam_role.cognito_admin_role.arn
 }
 
 resource "aws_cognito_identity_pool" "ims_identity_pool" {

--- a/cognito.tf
+++ b/cognito.tf
@@ -20,6 +20,13 @@ resource "aws_cognito_user_pool_client" "ims_cognito_client" {
   supported_identity_providers         = ["COGNITO"]
 }
 
+# Configure Cognito client style
+resource "aws_cognito_user_pool_ui_customization" "ims_user_pool_ui" {
+  css          = ".label-customizable {font-weight: 400;}"
+  user_pool_id = aws_cognito_user_pool_domain.ims_cognito_domain.user_pool_id
+  client_id    = aws_cognito_user_pool_client.ims_cognito_client.id
+}
+
 # Configure the Cognito User Groups
 resource "aws_cognito_user_group" "ims_user_group" {
   user_pool_id = aws_cognito_user_pool.ims_user_pool.id

--- a/cognito.tf
+++ b/cognito.tf
@@ -65,8 +65,8 @@ resource "aws_cognito_identity_pool_roles_attachment" "ims_identity_pool_roles" 
 
     mapping_rule {
       claim      = "cognito:groups"
-      match_type = "Equals"
-      value      = "Admins"
+      match_type = "Contains"
+      value      = aws_cognito_user_group.ims_admin_group.name
       role_arn   = aws_iam_role.cognito_admin_role.arn
     }
   }

--- a/cognito.tf
+++ b/cognito.tf
@@ -65,7 +65,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "ims_identity_pool_roles" 
 
     mapping_rule {
       claim      = "cognito:groups"
-      match_type = "Contains"
+      match_type = "Equals"
       value      = "Admins"
       role_arn   = aws_iam_role.cognito_admin_role.arn
     }

--- a/cognito.tf
+++ b/cognito.tf
@@ -59,7 +59,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "ims_identity_pool_roles" 
   role_mapping {
     identity_provider         = "${aws_cognito_user_pool.ims_user_pool.endpoint}:${aws_cognito_user_pool_client.ims_cognito_client.id}"
     ambiguous_role_resolution = "AuthenticatedRole"
-    type                      = "Token"
+    type                      = "Rules"
 
     mapping_rule {
       claim      = "cognito:groups"

--- a/cognito.tf
+++ b/cognito.tf
@@ -1,0 +1,32 @@
+# Configure AWS Cognito User Pool
+resource "aws_cognito_user_pool" "ims_user_pool" {
+  name = "ims-user-pool"
+}
+
+# Configure the domain for the Cognito User Pool
+resource "aws_cognito_user_pool_domain" "ims_cognito_domain" {
+  domain       = "ims-signin"
+  user_pool_id = aws_cognito_user_pool.ims_user_pool.id
+}
+
+# Configure the client for the Cognito User Pool
+resource "aws_cognito_user_pool_client" "ims_cognito_client" {
+  name                                 = "ims-cognito-client"
+  user_pool_id                         = aws_cognito_user_pool.ims_user_pool.id
+  callback_urls                        = ["https://oauth.pstmn.io/v1/browser-callback"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["email", "openid", "profile"]
+  supported_identity_providers         = ["COGNITO"]
+}
+
+# Configure the Cognito User Groups
+resource "aws_cognito_user_group" "ims_user_group" {
+  user_pool_id = aws_cognito_user_pool.ims_user_pool.id
+  name         = "Users"
+}
+
+resource "aws_cognito_user_group" "ims_admin_group" {
+  user_pool_id = aws_cognito_user_pool.ims_user_pool.id
+  name         = "Admins"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy" "user_allow_policy" {
     Statement = [{
       Effect   = "Allow",
       Action   = ["execute-api:Invoke"],
-      Resource = ["arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test"]
+      Resource = ["arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/*"]
     }]
   })
 }
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy" "user_deny_policy" {
       Effect = "Deny",
       Action = ["execute-api:Invoke"],
       Resource = [
-        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test_admin/*"
+        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/GET/auth_test_admin"
       ]
     }]
   })

--- a/iam.tf
+++ b/iam.tf
@@ -73,7 +73,7 @@ resource "aws_iam_role_policy" "user_deny_policy" {
       Effect = "Deny",
       Action = ["execute-api:Invoke"],
       Resource = [
-        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test_admin/*",
+        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test_admin/*"
       ]
     }]
   })

--- a/iam.tf
+++ b/iam.tf
@@ -29,6 +29,7 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
 }
 
 # Cognito User Role
+# Source: https://docs.aws.amazon.com/cognito/latest/developerguide/role-based-access-control.html
 resource "aws_iam_role" "cognito_user_role" {
   name = "CognitoUserRole"
   assume_role_policy = jsonencode({
@@ -59,7 +60,7 @@ resource "aws_iam_role_policy" "user_allow_policy" {
     Statement = [{
       Effect   = "Allow",
       Action   = ["execute-api:Invoke"],
-      Resource = ["arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/*"]
+      Resource = ["arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test"]
     }]
   })
 }

--- a/iam.tf
+++ b/iam.tf
@@ -73,7 +73,7 @@ resource "aws_iam_role_policy" "user_deny_policy" {
       Effect = "Deny",
       Action = ["execute-api:Invoke"],
       Resource = [
-        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test_admin/GET",
+        "arn:aws:execute-api:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.ims_api.id}/${aws_api_gateway_stage.ims_api_stage_deployment.stage_name}/auth_test_admin/*",
       ]
     }]
   })

--- a/iam.tf
+++ b/iam.tf
@@ -21,6 +21,23 @@ resource "aws_iam_role" "lambda_exec_role" {
   }
 }
 
+# Get credentials lambda function policy
+resource "aws_iam_policy" "get_credentials_policy" {
+  name        = "get-credentials-policy"
+  description = "Policy for the get_credentials lambda function"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Action = [
+        "cognito-identity:GetId",
+        "cognito-identity:GetCredentialsForIdentity"
+      ],
+      Resource = ["arn:aws:cognito-identity:${var.aws_region}:${data.aws_caller_identity.current.account_id}:identitypool/${aws_cognito_identity_pool.ims_identity_pool.id}"]
+    }]
+  })
+}
+
 # Attach predefined policy tp previously created role
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_exec_role.name

--- a/lambda.tf
+++ b/lambda.tf
@@ -107,6 +107,7 @@ module "get_credentials" {
   environment_variables = {
     "IDENTITY_POOL_ID" = aws_cognito_identity_pool.ims_identity_pool.id
     "AWS_ACCOUNT_ID"   = data.aws_caller_identity.current.account_id
+    "USER_POOL_ID"     = aws_cognito_user_pool.ims_user_pool.id
     "TF_AWS_REGION"    = var.aws_region
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,4 +1,3 @@
-
 module "hello_world" {
   source        = "terraform-aws-modules/lambda/aws"
   version       = "7.20.0"
@@ -30,6 +29,48 @@ module "move_store_item" {
   architectures = ["arm64"]
   timeout       = 120
   source_path   = "${path.module}/lambdas/move_store_item/"
+  publish       = true
+
+  # Allow the API Gateway to invoke the Lambda functions
+  allowed_triggers = {
+    APIGatewayAny = {
+      service    = "apigateway"
+      source_arn = "${aws_api_gateway_rest_api.ims_api.execution_arn}/*/*" # Allow access from any method and path
+    }
+  }
+}
+
+module "auth_test_user" {
+  source        = "terraform-aws-modules/lambda/aws"
+  version       = "7.20.0"
+  function_name = "auth_test_user"
+  description   = "Testing if the lambda function can be invoked by any authenticated user via the API Gateway"
+  handler       = "auth_test_user.lambda_handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  timeout       = 120
+  source_path   = "${path.module}/lambdas/auth_test_user/"
+  publish       = true
+
+  # Allow the API Gateway to invoke the Lambda functions
+  allowed_triggers = {
+    APIGatewayAny = {
+      service    = "apigateway"
+      source_arn = "${aws_api_gateway_rest_api.ims_api.execution_arn}/*/*" # Allow access from any method and path
+    }
+  }
+}
+
+module "auth_test_admin" {
+  source        = "terraform-aws-modules/lambda/aws"
+  version       = "7.20.0"
+  function_name = "auth_test_admin"
+  description   = "Testing if the lambda function can be invoked by any authorized admin via the API Gateway"
+  handler       = "auth_test_admin.lambda_handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  timeout       = 120
+  source_path   = "${path.module}/lambdas/auth_test_admin/"
   publish       = true
 
   # Allow the API Gateway to invoke the Lambda functions

--- a/lambda.tf
+++ b/lambda.tf
@@ -93,6 +93,8 @@ module "get_credentials" {
   timeout       = 120
   source_path   = "${path.module}/lambdas/get_credentials/"
   publish       = true
+  attach_policy = true
+  policy        = aws_iam_policy.get_credentials_policy.arn
 
   # Allow the API Gateway to invoke the Lambda functions
   allowed_triggers = {
@@ -104,6 +106,6 @@ module "get_credentials" {
 
   environment_variables = {
     "IDENTITY_POOL_ID" = aws_cognito_identity_pool.ims_identity_pool.id
-    "TF_AWS_REGION"       = var.aws_region
+    "TF_AWS_REGION"    = var.aws_region
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -106,6 +106,7 @@ module "get_credentials" {
 
   environment_variables = {
     "IDENTITY_POOL_ID" = aws_cognito_identity_pool.ims_identity_pool.id
+    "AWS_ACCOUNT_ID"   = data.aws_caller_identity.current.account_id
     "TF_AWS_REGION"    = var.aws_region
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -81,3 +81,29 @@ module "auth_test_admin" {
     }
   }
 }
+
+module "get_credentials" {
+  source        = "terraform-aws-modules/lambda/aws"
+  version       = "7.20.0"
+  function_name = "get_credentials"
+  description   = "Get the credentials of the user invoking the lambda function"
+  handler       = "get_credentials.lambda_handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  timeout       = 120
+  source_path   = "${path.module}/lambdas/get_credentials/"
+  publish       = true
+
+  # Allow the API Gateway to invoke the Lambda functions
+  allowed_triggers = {
+    APIGatewayAny = {
+      service    = "apigateway"
+      source_arn = "${aws_api_gateway_rest_api.ims_api.execution_arn}/*/*" # Allow access from any method and path
+    }
+  }
+
+  environment_variables = {
+    "IDENTITY_POOL_ID" = aws_cognito_identity_pool.ims_identity_pool.id
+    "TF_AWS_REGION"       = var.aws_region
+  }
+}

--- a/lambdas/auth_test_admin/auth_test_admin.py
+++ b/lambdas/auth_test_admin/auth_test_admin.py
@@ -1,0 +1,13 @@
+import json
+
+def lambda_handler(event, context):
+    response = {
+        "statusCode" : 200,
+        "headers" : {
+            "Content-Type" : "application/json"
+        },
+        "body" : json.dumps({
+            "message" : "Hello authorized admin!"
+        })
+    }
+    return response

--- a/lambdas/auth_test_user/auth_test_user.py
+++ b/lambdas/auth_test_user/auth_test_user.py
@@ -1,0 +1,13 @@
+import json
+
+def lambda_handler(event, context):
+    response = {
+        "statusCode" : 200,
+        "headers" : {
+            "Content-Type" : "application/json"
+        },
+        "body" : json.dumps({
+            "message" : "Hello authenticated user!"
+        })
+    }
+    return response

--- a/lambdas/get_credentials/get_credentials.py
+++ b/lambdas/get_credentials/get_credentials.py
@@ -8,6 +8,7 @@ def lambda_handler(event, context):
     account_id = os.getenv("AWS_ACCOUNT_ID")
     aws_region = os.getenv("TF_AWS_REGION")
     identity_pool_id = os.getenv("IDENTITY_POOL_ID")
+    user_pool_id = os.getenv("USER_POOL_ID")
 
     # Initialize the Cognito Identity client
     identity_client = boto3.client("cognito-identity")
@@ -17,7 +18,7 @@ def lambda_handler(event, context):
         AccountId = account_id,
         IdentityPoolId = identity_pool_id,
         Logins = {
-            f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
+            f"cognito-idp.{aws_region}.amazonaws.com/{user_pool_id}": id_token
         }
     )
     identity_id = identity_response["IdentityId"]
@@ -26,7 +27,7 @@ def lambda_handler(event, context):
     credentials_response = identity_client.get_credentials_for_identity(
         IdentityId = identity_id,
         Logins = {
-            f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
+            f"cognito-idp.{aws_region}.amazonaws.com/{user_pool_id}": id_token
         }
     )
     credentials = credentials_response["Credentials"]

--- a/lambdas/get_credentials/get_credentials.py
+++ b/lambdas/get_credentials/get_credentials.py
@@ -3,7 +3,9 @@ import boto3
 import os
 
 def lambda_handler(event, context):
-    id_token = event["headers"]["Authorization"]
+    auth_header = event["headers"]["Authorization"]
+    id_token = auth_header.split(" ")[1] # Remove the "Bearer" prefix
+    account_id = os.getenv("AWS_ACCOUNT_ID")
     aws_region = os.getenv("TF_AWS_REGION")
     identity_pool_id = os.getenv("IDENTITY_POOL_ID")
 
@@ -12,6 +14,7 @@ def lambda_handler(event, context):
 
     # Get the identity id
     identity_response = identity_client.get_id(
+        AccountId = account_id,
         IdentityPoolId = identity_pool_id,
         Logins = {
             f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token

--- a/lambdas/get_credentials/get_credentials.py
+++ b/lambdas/get_credentials/get_credentials.py
@@ -26,7 +26,6 @@ def lambda_handler(event, context):
             f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
         }
     )
-
     credentials = credentials_response["Credentials"]
 
     return {

--- a/lambdas/get_credentials/get_credentials.py
+++ b/lambdas/get_credentials/get_credentials.py
@@ -4,12 +4,14 @@ import os
 
 def lambda_handler(event, context):
     id_token = event["headers"]["Authorization"]
-    client = boto3.client("cognito-idp")
     aws_region = os.getenv("TF_AWS_REGION")
     identity_pool_id = os.getenv("IDENTITY_POOL_ID")
 
+    # Initialize the Cognito Identity client
+    identity_client = boto3.client("cognito-identity")
+
     # Get the identity id
-    identity_response = client.get_id(
+    identity_response = identity_client.get_id(
         IdentityPoolId = identity_pool_id,
         Logins = {
             f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
@@ -18,7 +20,7 @@ def lambda_handler(event, context):
     identity_id = identity_response["IdentityId"]
 
     # Get the user's credentials from the identity pool
-    credentials_response = client.get_credentials_for_identity(
+    credentials_response = identity_client.get_credentials_for_identity(
         IdentityId = identity_id,
         Logins = {
             f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token

--- a/lambdas/get_credentials/get_credentials.py
+++ b/lambdas/get_credentials/get_credentials.py
@@ -1,0 +1,41 @@
+import json
+import boto3
+import os
+
+def lambda_handler(event, context):
+    id_token = event["headers"]["Authorization"]
+    client = boto3.client("cognito-idp")
+    aws_region = os.getenv("TF_AWS_REGION")
+    identity_pool_id = os.getenv("IDENTITY_POOL_ID")
+
+    # Get the identity id
+    identity_response = client.get_id(
+        IdentityPoolId = identity_pool_id,
+        Logins = {
+            f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
+        }
+    )
+    identity_id = identity_response["IdentityId"]
+
+    # Get the user's credentials from the identity pool
+    credentials_response = client.get_credentials_for_identity(
+        IdentityId = identity_id,
+        Logins = {
+            f"cognito-idp.{aws_region}.amazonaws.com/{identity_pool_id}": id_token
+        }
+    )
+
+    credentials = credentials_response["Credentials"]
+
+    return {
+        "statusCode" : 200,
+        "headers" : {
+            "Content-Type" : "application/json"
+        },
+        "body": json.dumps({
+            "message": "Temporary AWS credentials granted!",
+            "AccessKeyId": credentials["AccessKeyId"],
+            "SecretKey": credentials["SecretKey"],
+            "SessionToken": credentials["SessionToken"]
+        })
+    }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "5.88.0"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-3"
+  region = var.aws_region
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -483,7 +483,7 @@ paths:
       summary: Temporary endpoint to test authenticaiton
       operationId: authTest
       security:
-        - cognito_token_authorizer: []
+        - cognito_iam_authorizer: []
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -504,7 +504,7 @@ paths:
       summary: Temporary endpoint to test admin authorization
       operationId: authTestAdmin
       security:
-        - cognito_token_authorizer: []
+        - cognito_iam_authorizer: []
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -517,6 +517,24 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         '403':
           $ref: '#/components/responses/ForbiddenResponse'
+  /get_credentials:
+    get:
+      tags:
+      - Authorization
+      summary: Get temporary AWS credentials from Cognito ID token
+      operationId: getCredentials
+      security:
+        - cognito_token_authorizer: []
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "${get_credentials_arn}"
+        passthroughBehavior: "when_no_match"
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
 
 components:
   schemas:
@@ -570,6 +588,11 @@ components:
           example: 'Via Roma'
       type: object
   securitySchemes:
+    cognito_iam_authorizer:
+      type: apiKey
+      name: "Authorization"
+      in: "header"
+      x-amazon-apigateway-authtype: "awsSigv4"
     cognito_token_authorizer:
       type: apiKey
       name: "Authorization"
@@ -579,6 +602,7 @@ components:
         type: "COGNITO_USER_POOLS"
         providerARNs:
           - "${cognito_user_pool_arn}"
+
   responses:
     SuccessResponse:
       description: Success

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -475,6 +475,44 @@ paths:
   #         $ref: '#/components/responses/UnauthorizedResponse'
   #       '404':
   #         $ref: '#/components/responses/NotFoundResponse'
+  
+  /auth_test:
+    get:
+      tags: 
+        - Authentication Test
+      summary: Temporary endpoint to test authenticaiton
+      operationId: authTest
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "${auth_test_user_arn}"
+        passthroughBehavior: "when_no_match"
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+          
+  /auth_test_admin:
+    get:
+      tags: 
+        - Authentication Test
+      summary: Temporary endpoint to test admin authorization
+      operationId: authTestAdmin
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "${auth_test_admin_arn}"
+        passthroughBehavior: "when_no_match"
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
 
 components:
   schemas:
@@ -528,10 +566,15 @@ components:
           example: 'Via Roma'
       type: object
   securitySchemes:
-    JWTAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    cognito_token_authorizer:
+      type: apiKey
+      name: "Authorization"
+      in: "header"
+      x-amazon-apigateway-authtype: "COGNITO_USER_POOLS"
+      x-amazon-apigateway-authorizer:
+        type: "COGNITO_USER_POOLS"
+        providerARNs:
+          - "${cognito_user_pool_arn}"
   responses:
     SuccessResponse:
       description: Success

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -574,12 +574,11 @@ components:
       type: apiKey
       name: "Authorization"
       in: "header"
-      x-amazon-apigateway-authtype: "awsSigv4"
-      # x-amazon-apigateway-authtype: "COGNITO_USER_POOLS"
-      # x-amazon-apigateway-authorizer:
-      #   type: "COGNITO_USER_POOLS"
-      #   providerARNs:
-      #     - "${cognito_user_pool_arn}"
+      x-amazon-apigateway-authtype: "COGNITO_USER_POOLS"
+      x-amazon-apigateway-authorizer:
+        type: "COGNITO_USER_POOLS"
+        providerARNs:
+          - "${cognito_user_pool_arn}"
   responses:
     SuccessResponse:
       description: Success

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -574,11 +574,12 @@ components:
       type: apiKey
       name: "Authorization"
       in: "header"
-      x-amazon-apigateway-authtype: "COGNITO_USER_POOLS"
-      x-amazon-apigateway-authorizer:
-        type: "COGNITO_USER_POOLS"
-        providerARNs:
-          - "${cognito_user_pool_arn}"
+      x-amazon-apigateway-authtype: "awsSigv4"
+      # x-amazon-apigateway-authtype: "COGNITO_USER_POOLS"
+      # x-amazon-apigateway-authorizer:
+      #   type: "COGNITO_USER_POOLS"
+      #   providerARNs:
+      #     - "${cognito_user_pool_arn}"
   responses:
     SuccessResponse:
       description: Success

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -482,6 +482,8 @@ paths:
         - Authentication Test
       summary: Temporary endpoint to test authenticaiton
       operationId: authTest
+      security:
+        - cognito_token_authorizer: []
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -501,6 +503,8 @@ paths:
         - Authentication Test
       summary: Temporary endpoint to test admin authorization
       operationId: authTestAdmin
+      security:
+        - cognito_token_authorizer: []
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,11 @@
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+
+output "invoke_url" {
+  value = "${aws_api_gateway_rest_api.ims_api.execution_arn}/hello"
+}
+
 output "lambda_function_move_store_item_invoke_arn" {
   value = module.move_store_item.lambda_function_invoke_arn
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,11 @@
 output "lambda_function_move_store_item_invoke_arn" {
   value = module.move_store_item.lambda_function_invoke_arn
 }
+
+output "lambda_function_auth_test_user_invoke_arn" {
+  value = module.auth_test_user.lambda_function_invoke_arn
+}
+
+output "lambda_function_auth_test_admin_invoke_arn" {
+  value = module.auth_test_admin.lambda_function_invoke_arn
+}

--- a/variable.tf
+++ b/variable.tf
@@ -3,3 +3,9 @@ variable "environment" {
   description = "The environment"
   default     = "dev"
 }
+
+variable "aws_region" {
+  type        = string
+  description = "The AWS region"
+  default     = "eu-west-3"
+}


### PR DESCRIPTION
- Implemented authentication using Cognito User Pools and role-based access (authorization) using Cognito Identity Pools.
- The OpenAPI was set to use two authorizers: IAM policy one (for endpoints where roles are important) and a Cognito user pool one (for endpoints where authentication is sufficient).
- Added two test endpoints (`auth_test`, `auth_test_admin`) and a `get_credentials` one for retrieving temporary AWS credentials for authenticated users.